### PR TITLE
esn-frontend-application-grid#5: Now the targets of the anchors will be "_blank" if pointing to other apps

### DIFF
--- a/src/components/esn-app-grid/esn-app-grid.tsx
+++ b/src/components/esn-app-grid/esn-app-grid.tsx
@@ -2,6 +2,7 @@ import { Component, Prop, ComponentInterface, State, Host, h } from '@stencil/co
 import { Application } from './esn-app-grid.types';
 import { AppGridTogglerIcon } from '../../icons/AppGridIcon';
 import { getAppIcon } from '../../utils/app-icons';
+import { isParentPathnameOf } from '../../utils/pathname';
 
 @Component({
   tag: 'esn-app-grid',
@@ -57,7 +58,7 @@ export class EsnAppGrid implements ComponentInterface {
 
                 return (
                   <div class="esn-app-grid__app-item">
-                    <a href={url}>
+                    <a href={url} target={isParentPathnameOf(url, window.location.href) ? '_self' : '_blank'}>
                       <div class="esn-app-grid__app-icon">
                         <IconComponent />
                       </div>

--- a/src/utils/pathname.ts
+++ b/src/utils/pathname.ts
@@ -1,0 +1,3 @@
+export const isParentPathnameOf = (parentUrl: string, childUrl: string) => {
+  return parentUrl === childUrl || new RegExp(`${parentUrl}[^\\w\\d-_.~]`, 'g').test(childUrl);
+}


### PR DESCRIPTION
Resolves #5.

We'll use target="_blank" in the anchor tags that point to the other apps, while leave it to default (target="_self") for the current app.