### PR TITLE
esn-frontend-application-grid#17: Now the application grid works with relative URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   },
   "license": "AGPLv3",
   "dependencies": {
+    "@popperjs/core": "2.4.4",
     "@stencil/core": "1.12.2",
     "@stencil/sass": "1.3.2",
-    "@popperjs/core": "2.4.4"
+    "is-absolute-url": "3.0.3"
   }
 }

--- a/src/components/esn-app-grid/esn-app-grid.tsx
+++ b/src/components/esn-app-grid/esn-app-grid.tsx
@@ -3,6 +3,7 @@ import { Application } from './esn-app-grid.types';
 import { AppGridTogglerIcon } from '../../icons/AppGridIcon';
 import { getAppIcon } from '../../utils/app-icons';
 import { isParentPathnameOf } from '../../utils/pathname';
+import { getApplicationUrl } from '../../utils/url';
 
 @Component({
   tag: 'esn-app-grid',
@@ -60,10 +61,11 @@ export class EsnAppGrid implements ComponentInterface {
             <div class="esn-app-grid__popover-content">
               {applications.map(({ name, url }) => {
                 const IconComponent = getAppIcon(name);
+                const applicationUrl = getApplicationUrl(url);
 
                 return (
                   <div class="esn-app-grid__app-item">
-                    <a href={url} target={isParentPathnameOf(url, window.location.href) ? '_self' : '_blank'}>
+                    <a href={applicationUrl} target={isParentPathnameOf(applicationUrl, window.location.href) ? '_self' : '_blank'}>
                       <div class="esn-app-grid__app-icon">
                         <IconComponent />
                       </div>

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,3 @@
+import isAbsoluteUrl from 'is-absolute-url';
+
+export const getApplicationUrl = (url: string) => isAbsoluteUrl(url) ? url : new URL(url, window.location.origin).href;


### PR DESCRIPTION
Resolves https://github.com/OpenPaaS-Suite/esn-frontend-application-grid/issues/17.

Provided we are at https://dev.open-paas.org, and we have the following configuration:

```
APP_GRID_ITEMS=[{ "name": "Calendar", "url": "/calendar" }, { "name": "Contacts", "url": "contacts" }, { "name": "Inbox", "url": "/inbox/" }, { "name": "LinShare", "url": "https://linshare.linagora.com" }]
```

the application grid will have 4 items with the following urls:

- Calendar: https://dev.open-paas.org/calendar
- Contacts: https://dev.open-paas.org/contacts
- Inbox: https://dev.open-paas.org/inbox/
- LinShare: https://linshare.linagora.com